### PR TITLE
Add tests for both resolution and rejection.

### DIFF
--- a/segment-2/__tests__/exersise-03.js
+++ b/segment-2/__tests__/exersise-03.js
@@ -7,7 +7,21 @@ test('function returns promise', () => {
 })
 
 test('function returns promise that resolves if the argument is "green"', done => {
-  fn("green").then(val => {
+  fn("green")
+    .then(() => {
+      done()
+    })
+    .catch(() => {
+      new Error('Promise SHOULD be resolved!')
+    })
+})
+
+test('function returns promise that rejects if the argument is "red"', done => {
+  fn("red")
+  .then(() => {
+    new Error('Promise should NOT be resolved!')
+  })
+  .catch(() => {
     done()
   })
 })


### PR DESCRIPTION
Looks like exersise-03.js tests were simply a copy of exersise-02.js. This tries to fix that. 